### PR TITLE
simple fix to catastrophic crash

### DIFF
--- a/eleganttools/sddslib.py
+++ b/eleganttools/sddslib.py
@@ -1,4 +1,5 @@
 from . import sddspython  # https://aps.anl.gov/Accelerator-Operations-Physics/Software
+from os.path import exists
 
 
 class SDDS(sddspython.SDDS):
@@ -11,6 +12,7 @@ class SDDS(sddspython.SDDS):
 
     def __init__(self, path, index=0):
         super().__init__(index)
+        assert exists(path), f"SDDS file {path} does not exist."
         self.load(str(path))
 
     def as_dict(self) -> dict:


### PR DESCRIPTION
If the user gets the file address wrong, or a file gets deleted without realising, it causes a full crash of any kernel (e.g. jupyter notebook). This has caused some headaches in the past. This is a simple fix that allows the user to know something has gone wrong but without causing the kernel to crash.